### PR TITLE
fix: explicitly mark main branches as not prerelease

### DIFF
--- a/packages/semantic-release-common/lib/branches.js
+++ b/packages/semantic-release-common/lib/branches.js
@@ -1,14 +1,15 @@
 module.exports = [
     /* regular releases */
-    { name: "master", channel: "latest" },
-    { name: "main", channel: "latest" },
-    { name: "dev", channel: "latest" },
+    { name: "master", channel: "latest", prerelease: false },
+    { name: "main", channel: "latest", prerelease: false },
+    { name: "dev", channel: "latest", prerelease: false },
 
     /* maintenance releases, e.g. release/4.x */
     {
         name: "release/+([0-9])?(.{+([0-9]),x}).x",
         range: "${name.replace(/^release\\//g, '')}",
         channel: "${name.replace(/^release\\//g, '')}",
+        prerelease: false
     },
 
     /* beta releases */

--- a/packages/semantic-release-common/lib/branches.js
+++ b/packages/semantic-release-common/lib/branches.js
@@ -9,7 +9,7 @@ module.exports = [
         name: "release/+([0-9])?(.{+([0-9]),x}).x",
         range: "${name.replace(/^release\\//g, '')}",
         channel: "${name.replace(/^release\\//g, '')}",
-        prerelease: false
+        prerelease: false,
     },
 
     /* beta releases */


### PR DESCRIPTION
try to workaround issue in `@semantic-release/github` incorrectly marking releases as prereleases:

https://github.com/semantic-release/github/blob/master/lib/is-prerelease.js