### PR TITLE
fix: peer cloneman 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17973,7 +17973,7 @@
         "npm": ">= 7"
       },
       "peerDependencies": {
-        "cloneman": "^1.4.0"
+        "cloneman": "^1.8.0"
       }
     },
     "packages/semantic-release-common": {

--- a/packages/semantic-release-cloneman-plugin/package.json
+++ b/packages/semantic-release-cloneman-plugin/package.json
@@ -32,7 +32,7 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "cloneman": "^1.4.0"
+    "cloneman": "^1.8.0"
   },
   "engines": {
     "node": ">= 22.16",


### PR DESCRIPTION
Template needs to use at least version 1.8.0 of cloneman in order to use this plugin.

